### PR TITLE
Fixes for current git versions. (Plus an enhancement or two.)

### DIFF
--- a/bin/gitzone
+++ b/bin/gitzone
@@ -39,6 +39,7 @@ basename(realpath) eq '.git' or die "gitzone has to be run from a .git directory
 my $lock_file = realpath '.gitzone-lock';
 my $list_file = realpath '.gitzone-list';
 my $stash_file;
+my $read_only = 0;
 chdir '..';
 
 our $user = getpwuid $<;
@@ -137,7 +138,7 @@ sub process_files {
     process_file($_) for keys %files;
     check_zones();
 
-    if (@changed_files) {
+    if (@changed_files && !$read_only) {
 	print "adding changed files: @changed_files\n" if $verbosity >= 2;
 	git "add @changed_files";
     }
@@ -185,7 +186,7 @@ sub process_file {
     }
     close FILE;
 
-    if ($changed) {
+    if ($changed && !$read_only) {
 	print ">>> $file changed, saving\n" if $verbosity >= 3;
 
 	open FILE, '>', $file or die $!;

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -132,7 +132,7 @@ sub check_what_changed {
     }
 
     # parse diff output, add only valid zone names to %files for parsing
-    $files{$1} = 0 while m,^:(?:[\w.]+\s+){5}(?:[a-z0-9./-]+\s+)?([a-z0-9./-]+)$,gm;
+    $files{$1} = 0 while m,^:(?:[\w.]+\s+){5}(?:[A-Za-z0-9./-]+\s+)?([A-Za-z0-9./-]+)$,gm;
 }
 
 sub process_files {

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -312,8 +312,13 @@ sub pre_receive {
     File::Path->remove_tree($tmp_dir, verbose => 1);
     File::Path->make_path($tmp_dir, verbose => 1);
 
-    # checkout changes
-    git "checkout -qf $new";
+    # Extract the new commit.
+    # We do this with git archive, and then extract the resulting tar in the temporary directory.
+    # There really should be a better way to do this, but I can't find one.
+    git "archive $new | tar -C $tmp_dir -xf -";
+
+    # chdir into the temporary directory.
+    chdir $tmp_dir or die $!;
 
     # Go read only, no actual changes in the pre-release hook.
     $read_only = 1;
@@ -322,6 +327,8 @@ sub pre_receive {
     load_repo_config;
     process_files;
 
+    # Go back to the repo.
+    chdir $base_cwd;
 
     # Save the file list, this is of questionable value at this point.
     save_list_file;

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -399,7 +399,11 @@ sub post_receive {
     # Actually install the new zone files.
     install_zones;
 
-    print "Done. Don't forget to pull if you use auto increment.\n";
+    if (@changed_files) {
+	print "Done. Auto increment applied, don't forget to pull.\n";
+    } else {
+	print "Done.\n";
+    }
 }
 
 sub post_commit {

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -373,6 +373,17 @@ sub post_receive {
 
     load_repo_config;
     load_list_file;
+
+    # Go through and process the files again, this time allowing changes.
+    # All of the AUTO_INCREMENT stuff happens here.
+    # The zone files are checked a second time as well.
+    process_files;
+
+    # Commit any auto increment changes.
+    if (@changed_files) {
+	git "commit -nm 'auto increment: @changed_files'", 1;
+    }
+
     install_zones;
 
     print "Done. Don't forget to pull if you use auto increment.\n";

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -314,10 +314,13 @@ sub pre_receive {
 
     # checkout changes
     git "checkout -qf $new";
+
+    # Go read only, no actual changes in the pre-release hook.
+    $read_only = 1;
+
     check_what_changed($old, $new);
     load_repo_config;
     process_files;
-    git "commit -nm 'auto increment: @changed_files'", 1 if @changed_files;
     save_list_file;
 
     # save new commits in a new branch

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -396,6 +396,7 @@ sub post_receive {
 	git "commit -nm 'auto increment: @changed_files'", 1;
     }
 
+    # Actually install the new zone files.
     install_zones;
 
     print "Done. Don't forget to pull if you use auto increment.\n";

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -314,6 +314,10 @@ sub pre_receive {
     push(@dir, $repo_name);
     my $tmp_dir = join('/', @dir);
 
+    # Do the diff and find out exactly what changed.
+    # This must be done before the chdir below.
+    check_what_changed($old, $new);
+
     # Make the temporary directory from scratch.
     File::Path->remove_tree($tmp_dir, verbose => 1);
     File::Path->make_path($tmp_dir, verbose => 1);
@@ -329,7 +333,6 @@ sub pre_receive {
     # Go read only, no actual changes in the pre-release hook.
     $read_only = 1;
 
-    check_what_changed($old, $new);
     load_repo_config;
     process_files;
 

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -132,7 +132,7 @@ sub check_what_changed {
     }
 
     # parse diff output, add only valid zone names to %files for parsing
-    $files{$1} = 0 while m,^:(?:[\w.]+\s+){5}([a-z0-9./-]+)$,gm;
+    $files{$1} = 0 while m,^:(?:[\w.]+\s+){5}(?:[a-z0-9./-]+\s+)?([a-z0-9./-]+)$,gm;
 }
 
 sub process_files {

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -335,9 +335,6 @@ sub pre_receive {
 
     # Go back to the repo.
     chdir $base_cwd;
-
-    # Save the file list, this is of questionable value at this point.
-    save_list_file;
 }
 
 sub pre_commit {
@@ -384,7 +381,6 @@ sub post_receive {
     git 'checkout -f master';
 
     load_repo_config;
-    load_list_file;
 
     # Go through and process the files again, this time allowing changes.
     # All of the AUTO_INCREMENT stuff happens here.

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -349,6 +349,22 @@ sub pre_commit {
 }
 
 sub post_receive {
+    my ($old, $new, $ref);
+
+    while (<STDIN>) { # <old-value> SP <new-value> SP <ref-name> LF
+	print if $verbosity >= 1;
+	next unless m,(\w+) (\w+) ([\w/]+),;
+	next if $3 ne 'refs/heads/master'; # only process master branch
+	die "Denied branch 'new', choose another name\n" if $3 eq 'refs/head/new';
+	($old, $new, $ref) = ($1, $2, $3);
+    }
+
+    # nothing for master branch, exit
+    clean_exit 0 unless $ref;
+
+    # Repeat the check_what_changed from the pre_receive.
+    check_what_changed($old, $new);
+
     print "\n";
 
     # move master to new

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -179,9 +179,15 @@ sub process_file {
 		    die "Error in $file:$n: invalid included file name, it should start with: $repo/\n";
 		}
 	    }
+
+	    # Try and feed INCLUDE files with relative path names into the list.
+	    # This should allow having a common header with an AUTO_INCREMENTed serial number.
+	    if ($inc_file =~ m|^$repo/(.*)|) {
+		push (@inc_by, $1);
+	    }
 	} else {
 	    if ($n == 1 && /^;INCLUDED_BY\s+(.*)$/) {
-		@inc_by = split /\s+/, $1;
+		push(@inc_by, split /\s+/, $1);
 	    }
 	}
 	push @newfile, $line;

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -367,9 +367,8 @@ sub post_receive {
 
     print "\n";
 
-    # move master to new
+    # Grab the current master.
     git 'checkout -f master';
-    git 'reset --hard new';
 
     load_repo_config;
     load_list_file;

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -31,6 +31,8 @@ use POSIX qw/strftime/;
 use Cwd qw/cwd realpath/;
 use File::Basename qw/fileparse basename/;
 use File::Temp;
+use File::Path;
+use File::Spec;
 
 @ARGV >= 2 or die "Usage: gitzone /path/to/gitzone.conf <command>\n";
 chdir '.git' if -d '.git';
@@ -297,6 +299,18 @@ sub pre_receive {
 
     # nothing for master branch, exit
     clean_exit 0 unless $ref;
+
+    # Figure out the paths for the repo, and the temporary checkout location.
+    my $base_cwd = cwd;
+    my @dir = File::Spec->splitdir($base_cwd);
+    my $repo_name = $dir[$#dir];
+    $dir[$#dir] .= '_tmp';
+    push(@dir, $repo_name);
+    my $tmp_dir = join('/', @dir);
+
+    # Make the temporary directory from scratch.
+    File::Path->remove_tree($tmp_dir, verbose => 1);
+    File::Path->make_path($tmp_dir, verbose => 1);
 
     # checkout changes
     git "checkout -qf $new";

--- a/bin/gitzone
+++ b/bin/gitzone
@@ -321,13 +321,10 @@ sub pre_receive {
     check_what_changed($old, $new);
     load_repo_config;
     process_files;
-    save_list_file;
 
-    # save new commits in a new branch
-    git 'branch -f  new';
-    git 'checkout';
-    # was: git 'checkout -B new';
-    # removed for back-compat with old git
+
+    # Save the file list, this is of questionable value at this point.
+    save_list_file;
 }
 
 sub pre_commit {

--- a/hooks/post-receive
+++ b/hooks/post-receive
@@ -1,6 +1,4 @@
 #!/bin/sh
 
 #(date; echo post-receive) >> ~/gitzone.log
-if [ -f .gitzone-list ]; then
-  /usr/bin/gitzone /etc/gitzone.conf post-receive # 2>&1 | tee -a ~/gitzone.log
-fi
+/usr/bin/gitzone /etc/gitzone.conf post-receive # 2>&1 | tee -a ~/gitzone.log


### PR DESCRIPTION
This is primarily (aside from the last few commits) fixes for #5 

We are now running all of the sanity checks twice, once in pre_receive, and once in post_receive.

The checks in pre_receive no longer make any changes, but they do all of the sanity checking.

The checks in post_receive now make all of the changes and commit them.

Because we can't do a checkout, we now grab the code into a new temporary directory using git archive piped into tar, I'm still surprised that I have not found a better way to do that, but it works.

Note, if someone has a repo named foo _and_ a repo named foo_tmp, this will stomp on foo_tmp.  We could use a completely different temporary directory name easily enough, possibly even building it with File::Temp, but I didn't think that it would be a major issue.
(It wouldn't be hard to change though.)

There are also three unrelated changes:
1: We now handle file renames correctly.
2: We allow upper case characters in the file names.
3: We follow $INCLUDE statements when checking files, not just ;INCLUDED_BY statements.

I can split those out into a separate PR if that is desired.